### PR TITLE
Refactor logging interface to have one function

### DIFF
--- a/examples/example_basic.c
+++ b/examples/example_basic.c
@@ -4,19 +4,19 @@
 int main(void)
 {
     int foo = 0;
-    log_info(stdout,    "This is a message created with log_info     foo = %d", foo++);
-    log_debug(stdout,   "This is a message created with log_debug    foo = %d", foo++);
-    log_warning(stdout, "This is a message created with log_warning  foo = %d", foo++);
-    log_error(stdout,   "This is a message created with log_error    foo = %d", foo++);
-    log_fatal(stdout,   "This is a message created with log_fatal    foo = %d", foo++);
+    llog(LOG_INFO,    stdout, "This is a message created with log_info     foo = %d", foo++);
+    llog(LOG_DEBUG,   stdout,   "This is a message created with log_debug    foo = %d", foo++);
+    llog(LOG_WARNING, stdout, "This is a message created with log_warning  foo = %d", foo++);
+    llog(LOG_ERROR,   stdout,   "This is a message created with log_error    foo = %d", foo++);
+    llog(LOG_FATAL,   stdout,   "This is a message created with log_fatal    foo = %d", foo++);
 
 
-    set_global_log_config(LOG_ERROR | LOG_FATAL); // Log only error and fatal messages.
-    log_info(stdout,    "some info message");
-    log_debug(stdout,   "some debug message");
-    log_warning(stdout, "some warning message");
-    log_error(stdout,   "some error message");
-    log_fatal(stdout,   "some fatal message");
+    set_global_log_config(LOG_ERROR); // Log only error and fatal messages.
+    llog(LOG_INFO, stdout,    "some info message");
+    llog(LOG_DEBUG, stdout,   "some debug message");
+    llog(LOG_WARNING, stdout, "some warning message");
+    llog(LOG_ERROR, stdout,   "some error message");
+    llog(LOG_FATAL, stdout,   "some fatal message");
 
     return 0;
 }

--- a/examples/example_multithread.c
+++ b/examples/example_multithread.c
@@ -9,7 +9,7 @@
 void* log_nums(void* arg)
 {
     for (int i = 0; i < 1000; ++i)
-        log_info(stdout, "%d", i);
+        llog(LOG_INFO, stdout, "%d", i);
     return NULL;
 }
 #pragma GCC diagnostic pop

--- a/log.h
+++ b/log.h
@@ -3,17 +3,13 @@
 
 #include <stdio.h>
 
-#define LOG_INFO    0b00001
-#define LOG_DEBUG   0b00010
-#define LOG_WARNING 0b00100
-#define LOG_ERROR   0b01000
-#define LOG_FATAL   0b10000
-void set_global_log_config(int config);
+#define LOG_INFO    (1 << 0)
+#define LOG_DEBUG   (1 << 1)
+#define LOG_WARNING (1 << 2)
+#define LOG_ERROR   (1 << 3)
+#define LOG_FATAL   (1 << 4)
 
-void log_info   (FILE* stream, const char* format, ...);
-void log_debug  (FILE* stream, const char* format, ...);
-void log_warning(FILE* stream, const char* format, ...);
-void log_error  (FILE* stream, const char* format, ...);
-void log_fatal  (FILE* stream, const char* format, ...);
+void set_global_log_config(int config);
+void llog(int level, FILE* stream, const char* format, ...);
 
 #endif // !_SIMPLE_C_LOGGER


### PR DESCRIPTION
llog() is now the only function in this logger, and greatly simplifies
the calling convention. In accordance with many other popular logging
libraries, the log level is not a bitwise flag, but a hard cap, such
that any log severity below LOG_CUTOFF_LEVEL is ignored. While the if
statement at the start of llog's implementation could have been
implemented in a wrapping macro, this would require the log level be
declared extern, and thus open to more race conditions when changing.
This patch does not attempt to remedy the issues with writing to a file
before locking it.