### PR TITLE
Refactor internals of `llog()` to remove switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.o
 *.obj
 *.a
+.gitignore
+.gitattributes

--- a/log.c
+++ b/log.c
@@ -1,10 +1,5 @@
 #include "log.h"
 
-#define STR_INFO    "   INFO: "
-#define STR_DEBUG   "  DEBUG: "
-#define STR_WARNING "WARNING: "
-#define STR_ERROR   "  ERROR: "
-#define STR_FATAL   "  FATAL: "
 #define MAX_BUFF_SIZE 64
 
 #include <stdarg.h>
@@ -17,6 +12,13 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif // !LOG_USE_PTHREAD
 
 static int LOG_CUTOFF_LEVEL = LOG_INFO;
+static const char* const prefix_string[] = {
+    "   INFO: ",
+    "  DEBUG: ",
+    "WARNING: ",
+    "  ERROR: ",
+    "  FATAL: "
+};
 
 // This could be made an atomic_t instead to guarentee thread safety, but it
 // would be really unlikely to be needed...
@@ -52,26 +54,8 @@ void llog(int level, FILE* stream, const char* format, ...)
     }
     va_list args;
     va_start(args, format);
-    switch(level) {
-        case LOG_INFO:
-            _log(stream, STR_INFO, format, args);
-            break;
-        case LOG_DEBUG:
-            _log(stream, STR_DEBUG, format, args);
-            break;
-        case LOG_WARNING:
-            _log(stream, STR_WARNING, format, args);
-            break;
-        case LOG_ERROR:
-            _log(stream, STR_ERROR, format, args);
-            break;
-        case LOG_FATAL:
-            _log(stream, STR_FATAL, format, args);
-            break;
-        default:
-            // invalid level given, silently do nothing. This can easily be
-            // changed.
-            break;
+    if (level >= LOG_INFO && level <= LOG_FATAL) {
+        _log(stream, prefix_string[level], format, args);
     }
     va_end(args);
 }

--- a/log.h
+++ b/log.h
@@ -3,11 +3,11 @@
 
 #include <stdio.h>
 
-#define LOG_INFO    (1 << 0)
-#define LOG_DEBUG   (1 << 1)
-#define LOG_WARNING (1 << 2)
-#define LOG_ERROR   (1 << 3)
-#define LOG_FATAL   (1 << 4)
+#define LOG_INFO    0
+#define LOG_DEBUG   1
+#define LOG_WARNING 2
+#define LOG_ERROR   3
+#define LOG_FATAL   4
 
 void set_global_log_config(int config);
 void llog(int level, FILE* stream, const char* format, ...);


### PR DESCRIPTION
Greatly improve the readability of the `llog()` internals, making it
more extendible in the future also. Since the static string array in
`log.c` can easily be added to, more log levels can be added with
one line.

I would feel bad if I didn't show this trick and I forgot when sending
the last PR....